### PR TITLE
Update guzzle in composer.json so it's compatible with Laravel 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7",


### PR DESCRIPTION
Guzzle 6 was conflicting with Laravel 8.x which requires Guzzle 7, and I couldn't see any breaking changes between Guzzle 6 and 7 with this library, so it should just be a case of updating composer.json as this PR does.