### PR TITLE
Always return exception if request error occured.

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -145,7 +145,7 @@ class Configuration
 
             return $resp;
         } catch (RequestException $e) {
-            return $e->hasResponse() ? Psr7\str($e->getResponse()) : $e;
+            return $e;
         }
     }
 }


### PR DESCRIPTION
Method Configuration::post can throw an RequestException, but it doesn't return properly as a result.
1. Psr7\str is deprecated
2. Hardly to understand if error occurred and process it from returned `string` value.

Decision: always return `RequestException`