### PR TITLE
🐛  use Psr7\Message::toString instead of Psr7\str

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -145,7 +145,7 @@ class Configuration
 
             return $resp;
         } catch (RequestException $e) {
-            return $e->hasResponse() ? Psr7\str($e->getResponse()) : $e;
+            return $e->hasResponse() ? Psr7\Message::toString($e->getResponse()) : $e;
         }
     }
 }


### PR DESCRIPTION
Hello,

As it was said in #5, there are a depreciation related to GuzzleHttp.
The previously used `Psr7\str` has been deprecated in favor of `Psr7\Message::toString`.
https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Psr7.str.html

I also agree to accept the PR #5 and always return the Exception object. 

Tanuki, 