### PR TITLE
Fix compatible with php 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.51
+* Fix compatible with php 8.2
+
 ### 1.0.50
 * Added a response parameter to /messages/send and /messages/send-template called 'queued_response' that details why an email was queued.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "mailchimp/transactional",
-    "version": "1.0.50",
+    "version": "1.0.51",
     "description": "",
     "keywords": [
         "swagger",

--- a/lib/Api/AllowlistsApi.php
+++ b/lib/Api/AllowlistsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class AllowlistsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/ExportsApi.php
+++ b/lib/Api/ExportsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class ExportsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/InboundApi.php
+++ b/lib/Api/InboundApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class InboundApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/IpsApi.php
+++ b/lib/Api/IpsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class IpsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/MessagesApi.php
+++ b/lib/Api/MessagesApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class MessagesApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/MetadataApi.php
+++ b/lib/Api/MetadataApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class MetadataApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/RejectsApi.php
+++ b/lib/Api/RejectsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class RejectsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/SendersApi.php
+++ b/lib/Api/SendersApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class SendersApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/SubaccountsApi.php
+++ b/lib/Api/SubaccountsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class SubaccountsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/TagsApi.php
+++ b/lib/Api/TagsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class TagsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/TemplatesApi.php
+++ b/lib/Api/TemplatesApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class TemplatesApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/UrlsApi.php
+++ b/lib/Api/UrlsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class UrlsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/UsersApi.php
+++ b/lib/Api/UsersApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class UsersApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/WebhooksApi.php
+++ b/lib/Api/WebhooksApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class WebhooksApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Api/WhitelistsApi.php
+++ b/lib/Api/WhitelistsApi.php
@@ -44,7 +44,7 @@ use MailchimpTransactional\ObjectSerializer;
  */
 class WhitelistsApi
 {
-    protected $Configuration;
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -46,6 +46,21 @@ class Configuration
     protected $requestClient;
     protected $defaultOutputFormat = '';
     protected $timeout = 300;
+    protected $allowlists;
+    protected $exports;
+    protected $inbound;
+    protected $ips;
+    protected $messages;
+    protected $metadata;
+    protected $rejects;
+    protected $senders;
+    protected $subaccounts;
+    protected $tags;
+    protected $templates;
+    protected $urls;
+    protected $users;
+    protected $webhooks;
+    protected $whitelists;
 
     public static $formatList = ['json', 'xml', 'php', 'yaml'];
 


### PR DESCRIPTION
Error occurs when using php 8.2
[Creation of dynamic property](https://wiki.php.net/rfc/deprecate_dynamic_properties) MailchimpTransactional\Api\AllowlistsApi::$config is deprecated. 